### PR TITLE
Fix: Radix Dialog + DropdownMenu pointer conflict

### DIFF
--- a/app/(root)/[type]/page.tsx
+++ b/app/(root)/[type]/page.tsx
@@ -21,6 +21,8 @@ export default async function Page({ searchParams, params }: SearchParamsProps )
     ) || "";
 
     const types = getFileTypesParams(type);     // Convert the type string to an array of FileType
+
+    console.log('Type: ', types);
     
     const files = await getFiles({
         types, 

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
 
   return(
      <div className="flex-center h-screen">
-        <h1 className='text-3xl text-brand'>my name is jinuk</h1>
+        <h1 className='text-3xl text-brand'>dashboard</h1>
      </div>
   )
 }

--- a/components/main/action-dropdown.tsx
+++ b/components/main/action-dropdown.tsx
@@ -23,7 +23,7 @@ import {
     DropdownMenuItem,
     DropdownMenuLabel,
     DropdownMenuSeparator,
-    DropdownMenuTrigger,
+    DropdownMenuTrigger, 
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -52,7 +52,7 @@ export default function ActionDropdown( { file }: ActionDropdownProps) {
         setEmails([]);
 
         console.log("Modal closed and state reset");
-    };      // for the delete action modal overlay\
+    };
 
     // Troubleshooting: When using Shadcn Ui Dropdown or Dialog, due to state transition instability Pointer Event: None remains on <body>, preventing clicks
     // Processing: Both Dropdown and Modal detect the point, so Pointer Event: Auto-Recover is processed

--- a/components/main/action-dropdown.tsx
+++ b/components/main/action-dropdown.tsx
@@ -13,6 +13,7 @@ import { renameUploadedFile, updateFileShareUsers, deleteUploadedFile } from "@/
 import {
     Dialog,
     DialogContent,
+    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogTitle,
@@ -51,16 +52,22 @@ export default function ActionDropdown( { file }: ActionDropdownProps) {
         setName(file.name);
         setEmails([]);
 
-        console.log("Modal closed and state reset");
+        // console.log("Modal closed and state reset");
     };
 
     // Troubleshooting: When using Shadcn Ui Dropdown or Dialog, due to state transition instability Pointer Event: None remains on <body>, preventing clicks
     // Processing: Both Dropdown and Modal detect the point, so Pointer Event: Auto-Recover is processed
+    // Solution: When the action is details, rename, share, or delete, set Pointer Event: Auto on <body>
     useEffect(() => {
-        if (!modalOpen && !isDropdownOpen) {
+        if (
+          action?.value === "details" ||
+          action?.value === "rename"  ||
+          action?.value === "share"   ||
+          action?.value === "delete"
+        ) {
           document.body.style.pointerEvents = "auto";
         }
-      }, [modalOpen, isDropdownOpen, ]);
+      }, [action?.value]);
 
     // This function handles the action based on the selected action type
     const handleAction = async () => {
@@ -143,6 +150,11 @@ export default function ActionDropdown( { file }: ActionDropdownProps) {
         return(
             <DialogContent className="shad-dialog button">
                 
+                {/* Description readable only by pad reader */}
+                <DialogDescription className="sr-only">
+                    {action.label}: 
+                </DialogDescription>
+
                 {/*  Render the action detail modals */}
                 <DialogHeader className="flex flex-col gap-3">
                     <DialogTitle className="text-center text-light-100">

--- a/components/main/thumbnail.tsx
+++ b/components/main/thumbnail.tsx
@@ -10,7 +10,7 @@ interface TumbnailProps {
 }
 
 export default function Thumbnail( { type, extension, url, className, imageClassName }: TumbnailProps) {
-    const isImage = type === "image" && extension !== "svg";
+    const isImage = type === "image" && !["svg", "png", "jpg", "jpeg"].includes(extension.toLowerCase());
 
     return (
         <figure className={cn("thumbnail", className)}>
@@ -22,7 +22,7 @@ export default function Thumbnail( { type, extension, url, className, imageClass
                 className={cn(
                     "size-8 object-contain", 
                     imageClassName,
-                    isImage && "thumbnail-image"
+                    isImage && "thumbnail-image rounded-full"
                 )}
             />
         </figure>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -82,6 +82,9 @@ export const getFileIcon = (type: string | FileType, extension: string | undefin
           return "/assets/icons/file-document.svg";
         // Image
         case "svg":
+        case "jpg":
+        case "jpeg":
+        case "png":
           return "/assets/icons/file-image.svg";
         // Video
         case "mkv":

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -82,6 +82,7 @@ export const getFileIcon = (type: string | FileType, extension: string | undefin
           return "/assets/icons/file-document.svg";
         // Image
         case "svg":
+            return "/assets/icons/file-svg.svg";
         case "jpg":
         case "jpeg":
         case "png":

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -132,14 +132,16 @@ export const constructFileUrl = (bucketFileId: string) => {
 // Get file types based on the type parameter
 export const getFileTypesParams = (type: string): FileType[] => {
     switch (type) {
-        case "document":
-            return [ "document" ];
-        case "image":
-            return [ "image" ];
-        case "video":
-            return [ "video", "audio" ];
+        case "documents":
+            return ["document"];
+        case "images":
+            return ["image"];
+        case "media":
+            return ["video", "audio"];
+        case "others":
+            return ["other"];
         default:
-            return [ "document" ];
+            return ["document"];
     }
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
     images: {
         domains: [
             "images.rawpixel.com",
+            'cloud.appwrite.io'
         ]
     }, 
     experimental: {


### PR DESCRIPTION
**1. Changes: 변경사항**
- [ action.value가 특정 값 (rename, share, delete, details)일 때마다 document.body.style.pointerEvents를 auto로 강제 복원하는 로직 추가 ] 
- [ DialogPrimitive.Close 버튼 클릭 시, 상태 초기화가 누락되며 pointer 이벤트가 막히던 문제 해결]
- [ 기타 이미지 구분 로직 정비 (svg, png, jpg, jpeg 등 확장자 인식 개선 ]
- [ File Type 구분 에러 해결 ] 


**2. Issue: 문제**
- Radix UI 기반 Dialog가 닫힐 때 일부 경우에 body에 pointer-events: none이 남아 클릭이 차단됨
- Radix의 DismissableLayer와 상태 동기화 타이밍 불일치로 인해 발생하는 이슈라고 추측 중임
- 특히 DropdownMenu → Dialog 전환 후, X, Cancel 클릭으로 닫으면 문제가 발생

**3. Solution: 해결 방법**
`
useEffect(() => {
  if (
    action?.value === "details" ||
    action?.value === "rename" ||
    action?.value === "share" ||
    action?.value === "delete"
  ) {
    document.body.style.pointerEvents = "auto";
  }
}, [action?.value]);
`
: useEffect를 통한 action.value (rename, details, delete, download, share) 변경 시 사이드 이펙트 강제 복구 처리


**[Commit: 참고 커밋]**
    •    feat: fix Dialog close issue causing pointer-events to remain disabled (072aa87)
    •    Added svg, general image distinction function (bf64a44)
    •	 Solve thumbnail application to png, jpg, jpeg (c7fa8a2)


**[시도해본 테스트]**
1. rename, share, delete, details 액션 이후에도 모든 버튼/링크 정상 작동
2. DevTools로 body.style.pointerEvents 정상 복원 확인
3. X버튼, Cancel, submit 모두 클릭 후 UI 정상 상태 유지
4. File Type에 따른 다양한 이미지 구분 기능 정상 확인
